### PR TITLE
Add support docs and update contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,10 @@
 # How to Contribute
 
-We would love to accept your patches and contributions to this project.
+Since this repository is for Google-internal use only, we encourage you to first
+discuss proposed changes via
+[support](https://github.com/google/interop-ios-for-google-sdks#support).
+However, patches and contributions to this project may be accepted by following
+the guidelines below.
 
 ## Before you begin
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ required minor version, `100.x`, e.g.:
 If a breaking change is ever required, it should be done by renaming the library to a new name in
 this repo.
 
+## Support
+
+Please file issues or request support for the following SDKs rather than directly in this
+repository:
+- `RecaptchaInterop`:
+  [reCAPTCHA Enterprise](https://cloud.google.com/recaptcha-enterprise/docs/getting-support)
+
 ## Contributing
 
 See [Contributing](CONTRIBUTING.md) for more information on contributing to the project.


### PR DESCRIPTION
- Added a Support section in the README to point to the support resources of the respective SDKs.
  - Only contains reCAPTCHA Enterprise at present but will be expanded to include, for example, the `firebase-ios-sdk` [issues](https://github.com/firebase/firebase-ios-sdk/issues/new/choose) and/or [support](https://firebase.google.com/support) pages in the future.
- Updated the contributing guidelines to highlight that the repo is intended for Google-internal use.