### PR TITLE
[Infra] Upgrade to `clang-format@19`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Setup check
       run: |
         brew update
-        brew install clang-format@18
+        brew install clang-format@19
         brew install mint
         mint bootstrap
 


### PR DESCRIPTION
Upgrade `clang-format` to v19 since v18 is no longer available on Homebrew.