### PR TITLE
Update RecaptchaInterop.podspec for macOS support

### DIFF
--- a/RecaptchaInterop.podspec
+++ b/RecaptchaInterop.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
     :tag => 'CocoaPods-' + s.version.to_s
   }
   s.ios.deployment_target = '11.0'
+  s.osx.deployment_target = '10.13'
 
   base_dir = "RecaptchaEnterprise/RecaptchaInterop/"
 


### PR DESCRIPTION
This PR updates the RecaptchaInterop.podspec to add support for macOS.